### PR TITLE
Update HTML lang attr on convert

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -23,6 +23,9 @@
   "MSG_DYNAMIC_CONVERT": {
     "message": "Dynamic Convert"
   },
+  "MSG_UPDATE_LANG": {
+    "message": "Update Page Language (allows the browser to use the appropriate font)"
+  },
   "MSG_DEBUG_MODE": {
     "message": "Debug Mode"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -24,7 +24,7 @@
     "message": "Dynamic Convert"
   },
   "MSG_UPDATE_LANG": {
-    "message": "Update Page Language (allows the browser to use the appropriate font)"
+    "message": "Update webpage language attribute (helps the browser display the appropriate font)"
   },
   "MSG_DEBUG_MODE": {
     "message": "Debug Mode"

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -24,7 +24,7 @@
     "message": "動態轉換"
   },
   "MSG_UPDATE_LANG": {
-    "message": "更新頁面語言（讓瀏覽器使用適當的字體）"
+    "message": "同時更新網頁的語言屬性（有助於瀏覽器使用適當的字型）"
   },
   "MSG_DEBUG_MODE": {
     "message": "偵錯模式"

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -23,6 +23,9 @@
   "MSG_DYNAMIC_CONVERT": {
     "message": "動態轉換"
   },
+  "MSG_UPDATE_LANG": {
+    "message": "更新頁面語言（讓瀏覽器使用適當的字體）"
+  },
   "MSG_DEBUG_MODE": {
     "message": "偵錯模式"
   },

--- a/src/content/convert/convert-nodes.ts
+++ b/src/content/convert/convert-nodes.ts
@@ -14,7 +14,7 @@ export const convertNode: SConvertNode = async (state, target, nodes) => {
         .then(() => convertNodesText(target, parsedNodes))
         .then(texts => {
           state.mutationObserver?.disconnect();
-          updateHtmlLang(document.documentElement, target);
+          state.updateLang && updateHtmlLang(document.documentElement, target);
           updateNodes(parsedNodes, texts);
           state.mutationObserver?.observe(document, state.mutationOpt);
         }));

--- a/src/content/convert/convert-nodes.ts
+++ b/src/content/convert/convert-nodes.ts
@@ -1,6 +1,7 @@
 import { LangType, walkNode } from 'tongwen-core';
 import { convertNodesText } from '../services';
 import { CtState } from '../state';
+import { updateHtmlLang } from './update-html-lang';
 import { updateNodes } from './update-nodes';
 
 type SConvertNode = (state: CtState, target: LangType, nodes: Node[]) => Promise<void>;
@@ -13,6 +14,7 @@ export const convertNode: SConvertNode = async (state, target, nodes) => {
         .then(() => convertNodesText(target, parsedNodes))
         .then(texts => {
           state.mutationObserver?.disconnect();
+          updateHtmlLang(document.documentElement, target);
           updateNodes(parsedNodes, texts);
           state.mutationObserver?.observe(document, state.mutationOpt);
         }));

--- a/src/content/convert/convert-nodes.ts
+++ b/src/content/convert/convert-nodes.ts
@@ -1,7 +1,7 @@
 import { LangType, walkNode } from 'tongwen-core';
 import { convertNodesText } from '../services';
 import { CtState } from '../state';
-import { updateHtmlLang } from './update-html-lang';
+import { updateLangAttr } from './update-lang-attr';
 import { updateNodes } from './update-nodes';
 
 type SConvertNode = (state: CtState, target: LangType, nodes: Node[]) => Promise<void>;
@@ -14,8 +14,8 @@ export const convertNode: SConvertNode = async (state, target, nodes) => {
         .then(() => convertNodesText(target, parsedNodes))
         .then(texts => {
           state.mutationObserver?.disconnect();
-          state.updateLang && updateHtmlLang(document.documentElement, target);
           updateNodes(parsedNodes, texts);
+          state.updateLangAttr && updateLangAttr(document.documentElement, target);
           state.mutationObserver?.observe(document, state.mutationOpt);
         }));
 };

--- a/src/content/convert/update-html-lang.ts
+++ b/src/content/convert/update-html-lang.ts
@@ -1,0 +1,23 @@
+import { LangType } from 'tongwen-core';
+
+/**
+ * Should match all possible valid Chinese language tags:
+ *  - `zh`
+ *  - `zh-TW`
+ *  - `zh-Hant`
+ *  - `zh-Hant-SG`
+ *  - etc.
+ */
+const ZH_LANG_REGEXP = /^zh(-[a-z]+)*$/i;
+
+/**
+ * Updates the `html` element's `lang` attribute according to the target `LangType`
+ * only if `lang` is already a valid Chinese language tag:
+ *  - `LangType.s2t` -> `zh-Hant`
+ *  - `LangType.s2t` -> `zh-Hans`
+ */
+export function updateHtmlLang(htmlElement: HTMLElement, target: LangType) {
+  if (ZH_LANG_REGEXP.test(htmlElement.lang)) {
+    htmlElement.lang = target === LangType.s2t ? 'zh-Hant' : 'zh-Hans';
+  }
+}

--- a/src/content/convert/update-lang-attr.ts
+++ b/src/content/convert/update-lang-attr.ts
@@ -11,13 +11,13 @@ import { LangType } from 'tongwen-core';
 const ZH_LANG_REGEXP = /^zh(-[a-z]+)*$/i;
 
 /**
- * Updates the `html` element's `lang` attribute according to the target `LangType`
+ * Updates the element's `lang` attribute according to the target `LangType`
  * only if `lang` is already a valid Chinese language tag:
  *  - `LangType.s2t` -> `zh-Hant`
  *  - `LangType.s2t` -> `zh-Hans`
  */
-export function updateHtmlLang(htmlElement: HTMLElement, target: LangType) {
-  if (ZH_LANG_REGEXP.test(htmlElement.lang)) {
-    htmlElement.lang = target === LangType.s2t ? 'zh-Hant' : 'zh-Hans';
+export function updateLangAttr(element: HTMLElement, target: LangType) {
+  if (ZH_LANG_REGEXP.test(element.lang)) {
+    element.lang = target === LangType.s2t ? 'zh-Hant' : 'zh-Hans';
   }
 }

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -13,7 +13,7 @@ const mutationOpt: MutationObserverInit = {
 
 export interface CtState {
   zhType: ZhType;
-  updateLang: boolean;
+  updateLangAttr: boolean;
   debugMode: boolean;
   timeoutId: number | undefined;
   mutationOpt: MutationObserverInit;
@@ -22,14 +22,14 @@ export interface CtState {
   converting: Promise<any>;
 }
 
-const getUpdateLang = () => storage.get('general').then(({ general }) => general.updateLang);
+const getUpdateLangAttr = () => storage.get('general').then(({ general }) => general.updateLangAttr);
 const getDebugMode = () => storage.get('general').then(({ general }) => general.debugMode);
 
 export async function createCtState(): Promise<CtState> {
-  return Promise.all([getDetectLanguage(), getUpdateLang(), getDebugMode()]).then(
-    ([zhType, updateLang, debugMode]) => ({
+  return Promise.all([getDetectLanguage(), getUpdateLangAttr(), getDebugMode()]).then(
+    ([zhType, updateLangAttr, debugMode]) => ({
       zhType,
-      updateLang,
+      updateLangAttr,
       debugMode,
       timeoutId: undefined,
       mutationOpt,

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -13,6 +13,7 @@ const mutationOpt: MutationObserverInit = {
 
 export interface CtState {
   zhType: ZhType;
+  updateLang: boolean;
   debugMode: boolean;
   timeoutId: number | undefined;
   mutationOpt: MutationObserverInit;
@@ -21,15 +22,19 @@ export interface CtState {
   converting: Promise<any>;
 }
 
+const getUpdateLang = () => storage.get('general').then(({ general }) => general.updateLang);
 const getDebugMode = () => storage.get('general').then(({ general }) => general.debugMode);
 
 export async function createCtState(): Promise<CtState> {
-  return Promise.all([getDetectLanguage(), getDebugMode()]).then(([zhType, debugMode]) => ({
-    zhType,
-    debugMode,
-    timeoutId: undefined,
-    mutationOpt,
-    mutations: [],
-    converting: Promise.resolve(null),
-  }));
+  return Promise.all([getDetectLanguage(), getUpdateLang(), getDebugMode()]).then(
+    ([zhType, updateLang, debugMode]) => ({
+      zhType,
+      updateLang,
+      debugMode,
+      timeoutId: undefined,
+      mutationOpt,
+      mutations: [],
+      converting: Promise.resolve(null),
+    }),
+  );
 }

--- a/src/options/hooks/general/use-general-opt.ts
+++ b/src/options/hooks/general/use-general-opt.ts
@@ -21,7 +21,7 @@ export const useGeneralOpt = () => {
 
   const setSpaMode = pipe(getEventChecked, setGeneral('spaMode'));
 
-  const setUpdateLang = pipe(getEventChecked, setGeneral('updateLang'));
+  const setUpdateLangAttr = pipe(getEventChecked, setGeneral('updateLangAttr'));
 
   const setDebugMode = pipe(getEventChecked, setGeneral('debugMode'));
 
@@ -45,7 +45,7 @@ export const useGeneralOpt = () => {
     setBrowserAction,
     setDefaultTarget,
     setSpaMode,
-    setUpdateLang,
+    setUpdateLangAttr,
     setDebugMode,
   };
 };

--- a/src/options/hooks/general/use-general-opt.ts
+++ b/src/options/hooks/general/use-general-opt.ts
@@ -21,6 +21,8 @@ export const useGeneralOpt = () => {
 
   const setSpaMode = pipe(getEventChecked, setGeneral('spaMode'));
 
+  const setUpdateLang = pipe(getEventChecked, setGeneral('updateLang'));
+
   const setDebugMode = pipe(getEventChecked, setGeneral('debugMode'));
 
   useEffect(
@@ -43,6 +45,7 @@ export const useGeneralOpt = () => {
     setBrowserAction,
     setDefaultTarget,
     setSpaMode,
+    setUpdateLang,
     setDebugMode,
   };
 };

--- a/src/options/pages/general/GeneralSettings.tsx
+++ b/src/options/pages/general/GeneralSettings.tsx
@@ -5,7 +5,8 @@ import { autoConvertOptions, browserActionOptions, defaultTargetOptions } from '
 import { useGeneralOpt } from '../../hooks/general/use-general-opt';
 
 export const GeneralSettings: FC = () => {
-  const { general, setAutoConvert, setBrowserAction, setDefaultTarget, setSpaMode, setDebugMode } = useGeneralOpt();
+  const { general, setAutoConvert, setBrowserAction, setDefaultTarget, setSpaMode, setUpdateLang, setDebugMode } =
+    useGeneralOpt();
 
   return (
     <form>
@@ -38,6 +39,12 @@ export const GeneralSettings: FC = () => {
         label={i18n.getMessage('MSG_DYNAMIC_CONVERT')}
         checked={general.spaMode}
         onChange={setSpaMode}
+      />
+      <Checkbox
+        isSwitch={true}
+        label={i18n.getMessage('MSG_UPDATE_LANG')}
+        checked={general.updateLang}
+        onChange={setUpdateLang}
       />
       <Checkbox
         isSwitch={true}

--- a/src/options/pages/general/GeneralSettings.tsx
+++ b/src/options/pages/general/GeneralSettings.tsx
@@ -5,7 +5,7 @@ import { autoConvertOptions, browserActionOptions, defaultTargetOptions } from '
 import { useGeneralOpt } from '../../hooks/general/use-general-opt';
 
 export const GeneralSettings: FC = () => {
-  const { general, setAutoConvert, setBrowserAction, setDefaultTarget, setSpaMode, setUpdateLang, setDebugMode } =
+  const { general, setAutoConvert, setBrowserAction, setDefaultTarget, setSpaMode, setUpdateLangAttr, setDebugMode } =
     useGeneralOpt();
 
   return (
@@ -43,8 +43,8 @@ export const GeneralSettings: FC = () => {
       <Checkbox
         isSwitch={true}
         label={i18n.getMessage('MSG_UPDATE_LANG')}
-        checked={general.updateLang}
-        onChange={setUpdateLang}
+        checked={general.updateLangAttr}
+        onChange={setUpdateLangAttr}
       />
       <Checkbox
         isSwitch={true}

--- a/src/preference/schema/v2/general.ts
+++ b/src/preference/schema/v2/general.ts
@@ -19,5 +19,6 @@ export const generalSchema: Control<PrefGeneral> = dctrl({
   ),
   defaultTarget: vctrl(vldFn({ type: 'string', required: true, enum: [LangType.s2t, LangType.t2s] }), LangType.s2t),
   spaMode: isBoolean(true),
+  updateLang: isBoolean(false),
   debugMode: isBoolean(false),
 });

--- a/src/preference/schema/v2/general.ts
+++ b/src/preference/schema/v2/general.ts
@@ -19,6 +19,6 @@ export const generalSchema: Control<PrefGeneral> = dctrl({
   ),
   defaultTarget: vctrl(vldFn({ type: 'string', required: true, enum: [LangType.s2t, LangType.t2s] }), LangType.s2t),
   spaMode: isBoolean(true),
-  updateLang: isBoolean(false),
+  updateLangAttr: isBoolean(false),
   debugMode: isBoolean(false),
 });

--- a/src/preference/types/v2/general.ts
+++ b/src/preference/types/v2/general.ts
@@ -10,6 +10,6 @@ export interface PrefGeneral {
   browserAction: BrowserActionOpt;
   defaultTarget: LangType;
   spaMode: boolean;
-  updateLang: boolean;
+  updateLangAttr: boolean;
   debugMode: boolean;
 }

--- a/src/preference/types/v2/general.ts
+++ b/src/preference/types/v2/general.ts
@@ -10,5 +10,6 @@ export interface PrefGeneral {
   browserAction: BrowserActionOpt;
   defaultTarget: LangType;
   spaMode: boolean;
+  updateLang: boolean;
   debugMode: boolean;
 }

--- a/src/preference/upgrade/pref-fx-v1-to-v2.ts
+++ b/src/preference/upgrade/pref-fx-v1-to-v2.ts
@@ -27,6 +27,7 @@ export function prefFxV1ToV2(v1Pref: PrefFxV1): PrefV2 {
       browserAction: V1PrefFxActionEnum[v1Pref.iconAction] as BrowserActionOpt,
       defaultTarget: LangType.s2t,
       spaMode: true,
+      updateLang: false,
       debugMode: false,
     },
     menu: {

--- a/src/preference/upgrade/pref-fx-v1-to-v2.ts
+++ b/src/preference/upgrade/pref-fx-v1-to-v2.ts
@@ -27,7 +27,7 @@ export function prefFxV1ToV2(v1Pref: PrefFxV1): PrefV2 {
       browserAction: V1PrefFxActionEnum[v1Pref.iconAction] as BrowserActionOpt,
       defaultTarget: LangType.s2t,
       spaMode: true,
-      updateLang: false,
+      updateLangAttr: false,
       debugMode: false,
     },
     menu: {

--- a/src/preference/upgrade/pref-gc-v1-to-v2.ts
+++ b/src/preference/upgrade/pref-gc-v1-to-v2.ts
@@ -33,7 +33,7 @@ export function prefGcV1ToV2(v1Pref: PrefGcV1): PrefV2 {
       browserAction: TargetConverter[v1Pref.iconAction],
       defaultTarget: LangType.s2t,
       spaMode: true,
-      updateLang: false,
+      updateLangAttr: false,
       debugMode: false,
     },
     menu: {

--- a/src/preference/upgrade/pref-gc-v1-to-v2.ts
+++ b/src/preference/upgrade/pref-gc-v1-to-v2.ts
@@ -33,6 +33,7 @@ export function prefGcV1ToV2(v1Pref: PrefGcV1): PrefV2 {
       browserAction: TargetConverter[v1Pref.iconAction],
       defaultTarget: LangType.s2t,
       spaMode: true,
+      updateLang: false,
       debugMode: false,
     },
     menu: {


### PR DESCRIPTION
Hello 新同文堂 maintainers ✨ 

I've been focusing on learning traditional Chinese characters lately, and I've had a great time using the automatic conversion to view sites that don't support 正體中文 in traditional characters.

## Issue 🪲

The only issue I've encountered is that the `html` tag's `lang` attribute doesn't get updated which in a lot of cases causes the browser to dislpay the characters following the [大陸新字型](https://zh.wikipedia.org/wiki/%E6%96%B0%E5%AD%97%E5%BD%A2).

## Proposed solution 🔧

This PR adds a function called in `convertNode` to update the `html` element's `lang` attribute according to the target `LangType`. (only if `lang` is already a valid Chinese language tag)

I'm happy to answer any question or move any code to a better location if needed 🙇‍♀️

## Screenshots 🖼️ 

Here's an example on [cn.vuejs.org](https://cn.vuejs.org):

Please pay attention to the rendering of 進's 走之底 (「⻌」比「⻎」) and 架's lower half (「木」比「朩」), as well as the centered punctuation.

### `lang="zh-Hans"` 简体：
<img width="1392" alt="cn vuejs org zh-Hans 简体" src="https://user-images.githubusercontent.com/17215508/189311170-547992e6-4ac1-43b1-946a-9b29244c577d.png">

### `lang="zh-Hans"` 繁體 (差不多正體) **without this PR**:
<img width="1392" alt="cn vuejs org zh-Hans 繁體" src="https://user-images.githubusercontent.com/17215508/189311252-e5de76b1-3f78-4fb9-9161-434bfed3da25.png">

### `lang="zh-Hant"` 繁體 (確切正體) **with this PR**:
<img width="1392" alt="cn vuejs org zh-Hant 繁體" src="https://user-images.githubusercontent.com/17215508/189311284-0b1aeed7-162f-488d-8644-5ea73c5dde2c.png">
