### PR TITLE
Update `lang` attribute of every element

### DIFF
--- a/src/content/convert/convert-nodes.ts
+++ b/src/content/convert/convert-nodes.ts
@@ -15,7 +15,8 @@ export const convertNode: SConvertNode = async (state, target, nodes) => {
         .then(texts => {
           state.mutationObserver?.disconnect();
           updateNodes(parsedNodes, texts);
-          state.updateLangAttr && updateLangAttr(document.documentElement, target);
+          state.updateLangAttr &&
+            document.querySelectorAll<HTMLElement>('[lang|="zh"]').forEach(el => updateLangAttr(el, target));
           state.mutationObserver?.observe(document, state.mutationOpt);
         }));
 };


### PR DESCRIPTION
哈囉！:wave:

This PR addresses the issue pointed out in this comment: https://github.com/tongwentang/tongwentang-extension/pull/60#issuecomment-1317504129

> So I had some time to look into this, and on Wikipedia, the `html` elements's `lang` attribute is indeed updated properly, but as you can see in the screenshot below, basically every element that holds text such as the main content, but also the nav bars and menus have their own `lang` attributes which don't get updated currently.
>
> I've opened a PR that updates the `lang` attribute on every element that already has a Chinese `lang` attribute &rarr; https://github.com/tongwentang/tongwentang-extension/pull/64
>
> Let me know what  you think :)
>
> <img width="1488" alt="image" src="https://user-images.githubusercontent.com/17215508/204026308-716b5939-4026-4ce8-ad52-c117d00d4c34.png">
