### PR TITLE
feat: add Safari Web Extension support with local Xcode generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,11 @@ $RECYCLE.BIN/
 
 web-ext-artifacts
 dict
+
+# Xcode / Safari
+DerivedData/
+*.xcuserstate
+*.xcodeproj/xcuserdata/
+*.xcworkspace/xcuserdata/
+*.xcodeproj/project.xcworkspace/
+safari/

--- a/README.md
+++ b/README.md
@@ -51,3 +51,36 @@ Run command:
 ```
 $ yarn dev:chromium
 ```
+
+#### Developing with Safari
+
+Build a Safari-compatible extension bundle:
+
+```
+$ npm run build:safari
+```
+
+Generate or refresh the Xcode project:
+
+```
+$ npm run safari:convert
+```
+
+The converter defaults to:
+
+- app name: `TongWenTang Safari`
+- bundle identifier: `io.github.tongwentang.safari`
+- project location: `./safari`
+
+You can override them when needed:
+
+```
+$ SAFARI_APP_NAME="TongWenTang Safari" \
+  SAFARI_BUNDLE_ID="io.github.tongwentang.safari" \
+  SAFARI_PROJECT_LOCATION="safari" \
+  npm run safari:convert
+```
+
+The generated `safari/` directory is a local build artifact and should not be committed.
+
+Then open `safari/TongWenTang Safari/TongWenTang Safari.xcodeproj` in Xcode and run the macOS app target once to install the extension into Safari.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import react from 'eslint-plugin-react';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
-const scripts = ['**/rspack.config.js', '**/manifest.js', '**/web-ext-config*.js'];
+const scripts = ['**/rspack.config.js', '**/manifest.js', '**/web-ext-config*.js', '**/scripts/**/*.{js,mjs,cjs}'];
 
 /**
  * @type {import('typescript-eslint').Config}

--- a/manifest.js
+++ b/manifest.js
@@ -11,12 +11,30 @@ const pkg = require('./package.json');
  */
 const createManifest = vendor => {
   const isFirefox = vendor === 'firefox';
+  const isSafari = vendor === 'safari';
   /** @type {Manifest.WebExtensionManifest['browser_specific_settings']} */
   const browser_specific_settings = isFirefox
     ? { gecko: { id: 'tongwen@softcup', strict_min_version: '63.0' } }
     : undefined;
   /** @type {Manifest.WebExtensionManifest['background']} */
   const background = isFirefox ? { scripts: ['background.js'] } : { service_worker: 'background.js' };
+  /** @type {Manifest.WebExtensionManifest['permissions']} */
+  const permissions = ['contextMenus', 'storage', 'tabs', 'unlimitedStorage'];
+
+  if (!isSafari) {
+    permissions.push('downloads', 'notifications');
+  }
+
+  /** @type {Manifest.WebExtensionManifest['optional_permissions']} */
+  const optional_permissions = isSafari ? undefined : ['clipboardWrite', 'clipboardRead'];
+  /** @type {Manifest.WebExtensionManifest['options_ui']} */
+  const options_ui = isSafari
+    ? { page: 'options.html' }
+    : {
+        browser_style: true,
+        open_in_tab: true,
+        page: 'options.html',
+      };
 
   return {
     manifest_version: 3,
@@ -33,8 +51,8 @@ const createManifest = vendor => {
       48: 'icons/tongwen-icon-48.png',
       128: 'icons/tongwen-icon-128.png',
     },
-    permissions: ['contextMenus', 'downloads', 'notifications', 'storage', 'tabs', 'unlimitedStorage'],
-    optional_permissions: ['clipboardWrite', 'clipboardRead'],
+    permissions,
+    optional_permissions,
     background,
     content_scripts: [
       {
@@ -52,11 +70,7 @@ const createManifest = vendor => {
         128: 'icons/tongwen-icon-128.png',
       },
     },
-    options_ui: {
-      browser_style: true,
-      open_in_tab: true,
-      page: 'options.html',
-    },
+    options_ui,
     commands: {
       w_s2t: {
         description: '__MSG_MSG_WEBPAGE_S2T__',

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "update": "ncu -i --format group",
     "we:build": "web-ext build -s dist/firefox",
     "we:sign": "web-ext sign --config=web-ext-config-firefox.mjs --no-config-discovery",
-    "prepare": "husky"
+    "prepare": "husky",
+    "dev:safari": "rspack build --mode=development --env vendor=safari",
+    "build:safari": "rspack build --mode=production --env vendor=safari",
+    "safari:convert": "npm run build:safari && node ./scripts/safari-convert.mjs"
   },
   "nano-staged": {
     "*.{js,jsx,ts,tsx,json,md}": [

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -102,7 +102,7 @@ module.exports = (env, argv) => {
           });
         });
 
-        if (isProd) return;
+        if (isProd || vendor === 'safari') return;
 
         compiler.hooks.afterDone.tap('start web-ext', () => {
           if (state.webExt) return;

--- a/scripts/safari-convert.mjs
+++ b/scripts/safari-convert.mjs
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const rootDir = process.cwd();
+const extensionPath = resolve(rootDir, 'dist', 'safari');
+const projectLocation = resolve(rootDir, process.env.SAFARI_PROJECT_LOCATION || 'safari');
+const appName = process.env.SAFARI_APP_NAME || 'TongWenTang Safari';
+const bundleIdentifier = process.env.SAFARI_BUNDLE_ID || 'io.github.tongwentang.safari';
+const projectFile = resolve(projectLocation, appName, `${appName}.xcodeproj`, 'project.pbxproj');
+
+if (!existsSync(extensionPath)) {
+  console.error(`Safari extension bundle not found at ${extensionPath}`);
+  process.exit(1);
+}
+
+const result = spawnSync(
+  'xcrun',
+  [
+    'safari-web-extension-converter',
+    extensionPath,
+    '--project-location',
+    projectLocation,
+    '--app-name',
+    appName,
+    '--bundle-identifier',
+    bundleIdentifier,
+    '--swift',
+    '--macos-only',
+    '--no-open',
+    '--no-prompt',
+    '--force',
+  ],
+  { stdio: 'inherit' },
+);
+
+if ((result.status ?? 1) !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+if (existsSync(projectFile)) {
+  const source = readFileSync(projectFile, 'utf8');
+  const patched = source.replace(/PRODUCT_BUNDLE_IDENTIFIER = ?"?([^";]+)"?;/g, (_, value) =>
+    value.endsWith('.Extension')
+      ? `PRODUCT_BUNDLE_IDENTIFIER = ${bundleIdentifier}.Extension;`
+      : `PRODUCT_BUNDLE_IDENTIFIER = "${bundleIdentifier}";`,
+  );
+
+  writeFileSync(projectFile, patched);
+}

--- a/src/background/clipboard/index.ts
+++ b/src/background/clipboard/index.ts
@@ -2,6 +2,7 @@ import { LangType } from 'tongwen-core/dictionaries';
 import { browser } from '../../service/browser';
 import { i18n } from '../../service/i18n/i18n';
 import { createNoti } from '../../service/notification/create-noti';
+import { IS_SAFARI } from '../../service/types';
 import { getConverter } from '../converter';
 
 const convertClipboardContent = async (target: LangType): Promise<void> =>
@@ -9,13 +10,27 @@ const convertClipboardContent = async (target: LangType): Promise<void> =>
     .then(([text, converter]) => converter.phrase(target, text))
     .then(async text => navigator.clipboard.writeText(text));
 
+const requestClipboardPermission = async (): Promise<boolean> => {
+  if (IS_SAFARI || !browser.permissions?.request) {
+    return true;
+  }
+
+  return browser.permissions.request({ permissions: ['clipboardRead', 'clipboardWrite'] });
+};
+
 export const convertClipboard = async (target: LangType): Promise<void> =>
-  browser.permissions
-    .request({ permissions: ['clipboardRead', 'clipboardWrite'] })
-    .then(async isGet => (isGet && (await convertClipboardContent(target)), isGet))
-    .then(isGet => {
+  requestClipboardPermission()
+    .then(async isGranted => {
+      if (!isGranted) {
+        return false;
+      }
+
+      await convertClipboardContent(target);
+      return true;
+    })
+    .then(isGranted => {
       createNoti(
-        i18n.getMessage(!isGet ? 'NT_GRT_PRM_DENIED' : target === LangType.s2t ? 'NT_CLB_TO_S2T' : 'NT_CLB_TO_T2S'),
+        i18n.getMessage(!isGranted ? 'NT_GRT_PRM_DENIED' : target === LangType.s2t ? 'NT_CLB_TO_S2T' : 'NT_CLB_TO_T2S'),
       );
     })
     .catch(() => void createNoti(i18n.getMessage('NT_GRT_PRM_ONLY_USR_INTER')));

--- a/src/background/menu/browser-action.ts
+++ b/src/background/menu/browser-action.ts
@@ -3,6 +3,7 @@ import { isUrlLike } from '../../preference/filter-rule';
 import type { FilterTarget } from '../../preference/types/v2';
 import { browser } from '../../service/browser';
 import { i18n } from '../../service/i18n/i18n';
+import { IS_SAFARI } from '../../service/types';
 import { addFilterRule } from '../../service/storage/local';
 import { getHostName, getRandomId } from '../../utilities';
 import { getSessionState, setSessionState } from '../session';
@@ -57,6 +58,10 @@ const createClipboardProperties = () =>
 
 // TODO: need icon
 export async function createBrowserActionMenus(): Promise<unknown> {
+  if (IS_SAFARI) {
+    return Promise.resolve();
+  }
+
   return getSessionState().then(async ({ hasBrowserActionMenu }) => {
     if (hasBrowserActionMenu) return;
 

--- a/src/service/i18n/i18n.ts
+++ b/src/service/i18n/i18n.ts
@@ -1,6 +1,76 @@
 import browser from 'webextension-polyfill';
+import enMessages from '../../_locales/en/messages.json';
+import zhTWMessages from '../../_locales/zh_TW/messages.json';
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace i18n {
-  export const { getMessage } = browser.i18n;
-}
+type MessageEntry = {
+  message: string;
+};
+
+type MessageMap = Record<string, MessageEntry>;
+
+const FALLBACK_MESSAGES = {
+  en: enMessages as MessageMap,
+  zh_TW: zhTWMessages as MessageMap,
+} as const;
+
+const DEFAULT_LOCALE = 'en';
+
+const toArray = (substitutions?: string | string[]) => {
+  if (substitutions == null) {
+    return [];
+  }
+
+  return Array.isArray(substitutions) ? substitutions : [substitutions];
+};
+
+const applySubstitutions = (message: string, substitutions?: string | string[]) =>
+  toArray(substitutions).reduce(
+    (value, substitution, index) => value.replaceAll(`$${index + 1}`, substitution),
+    message.replaceAll('$$', '$'),
+  );
+
+const getFallbackLocale = () => {
+  const candidates = [browser.i18n.getUILanguage?.(), ...(navigator.languages || []), navigator.language]
+    .filter(Boolean)
+    .map(locale => locale.replace('-', '_'));
+
+  for (const locale of candidates) {
+    if (locale in FALLBACK_MESSAGES) {
+      return locale as keyof typeof FALLBACK_MESSAGES;
+    }
+
+    if (locale.startsWith('zh')) {
+      return 'zh_TW';
+    }
+
+    if (locale.startsWith('en')) {
+      return 'en';
+    }
+  }
+
+  return DEFAULT_LOCALE;
+};
+
+const getFallbackMessage = (name: string, substitutions?: string | string[]) => {
+  const locale = getFallbackLocale();
+  const message = FALLBACK_MESSAGES[locale][name]?.message ?? FALLBACK_MESSAGES[DEFAULT_LOCALE][name]?.message ?? name;
+  return applySubstitutions(message, substitutions);
+};
+
+const getMessage = (name: string, substitutions?: string | string[]) => {
+  try {
+    const message = browser.i18n.getMessage(name, substitutions as never);
+
+    if (message) {
+      return message;
+    }
+  } catch {
+    return getFallbackMessage(name, substitutions);
+  }
+
+  return getFallbackMessage(name, substitutions);
+};
+
+export const i18n = {
+  getMessage,
+};

--- a/src/service/notification/create-noti.ts
+++ b/src/service/notification/create-noti.ts
@@ -2,12 +2,26 @@ import { getRandomId } from '../../utilities';
 import { browser } from '../browser';
 import { i18n } from '../i18n/i18n';
 
-const autoDeleteNoti = (id: string, closeIn: number) => setTimeout(async () => browser.notifications.clear(id), closeIn);
+const autoDeleteNoti = (id: string, closeIn: number) =>
+  setTimeout(async () => browser.notifications?.clear(id), closeIn);
 
-export const createNoti = async (message: string, closeIn = 5000, id = getRandomId()) => {
+const fallbackNotice = async (id: string, message: string): Promise<string> => {
+  if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+    window.alert(message);
+    return id;
+  }
+
+  console.info(`[${i18n.getMessage('NT_TITLE')}] ${message}`);
+  return id;
+};
+
+export const createNoti = async (message: string, closeIn = 5000, id = getRandomId()): Promise<string> => {
+  if (!browser.notifications?.create) {
+    return fallbackNotice(id, message);
+  }
+
   autoDeleteNoti(id, closeIn);
 
-  // TODO: need i18n
   return browser.notifications.create(id, {
     type: 'basic',
     title: i18n.getMessage('NT_TITLE'),

--- a/src/service/storage/export-pref.ts
+++ b/src/service/storage/export-pref.ts
@@ -5,18 +5,43 @@ import { createNoti } from '../notification/create-noti';
 import { BROWSER_TYPE } from '../types';
 import { getStorage } from './storage';
 
-const delayRevoke = (url: string) => setTimeout(() => { URL.revokeObjectURL(url); }, 60000);
+const delayRevoke = (url: string) =>
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 60000);
 
-export const exportPref = async () => {
-  // TODO: maybe we can optionally get the download permission here
-  return browser.downloads
-    ? getStorage()
-        .then(pref => safeUpgradePref(BROWSER_TYPE, pref))
-        .then(pref => new Blob([JSON.stringify(pref, null, 2)], { type: 'application/json;charset=utf-8' }))
-        .then(blob => URL.createObjectURL(blob))
-        .then(url => (delayRevoke(url), url))
-        .then(url => ({ url, filename: 'tongwentang-pref.json', saveAs: true }))
-        .then(browser.downloads.download)
-        .catch(async () => createNoti(i18n.getMessage('MSG_EXPORT_FAILED')))
-    : Promise.resolve();
-};
+const getPrefBlobUrl = async () =>
+  getStorage()
+    .then(pref => safeUpgradePref(BROWSER_TYPE, pref))
+    .then(pref => new Blob([JSON.stringify(pref, null, 2)], { type: 'application/json;charset=utf-8' }))
+    .then(blob => URL.createObjectURL(blob))
+    .then(url => (delayRevoke(url), url));
+
+const exportWithDownloads = async () =>
+  getPrefBlobUrl()
+    .then(url => ({ url, filename: 'tongwentang-pref.json', saveAs: true }))
+    .then(async option => browser.downloads!.download(option));
+
+const exportWithAnchor = async () =>
+  getPrefBlobUrl().then(url => {
+    if (typeof document === 'undefined') {
+      throw new Error('Document is unavailable');
+    }
+
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'tongwentang-pref.json';
+    anchor.style.display = 'none';
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+  });
+
+export const exportPref = async () =>
+  (browser.downloads?.download ? exportWithDownloads() : exportWithAnchor()).catch(async () => {
+    try {
+      await exportWithAnchor();
+    } catch {
+      await createNoti(i18n.getMessage('MSG_EXPORT_FAILED'));
+    }
+  });

--- a/src/service/types/index.ts
+++ b/src/service/types/index.ts
@@ -3,4 +3,8 @@ export enum BrowserType {
   GC = 'GC',
 }
 
-export const BROWSER_TYPE = navigator.userAgent.includes('Firefox') ? BrowserType.FX : BrowserType.GC;
+const userAgent = navigator.userAgent;
+
+export const IS_SAFARI = /Safari/.test(userAgent) && !/Chrome|Chromium|CriOS|Edg|OPR|Firefox|FxiOS/.test(userAgent);
+
+export const BROWSER_TYPE = userAgent.includes('Firefox') ? BrowserType.FX : BrowserType.GC;


### PR DESCRIPTION
## Summary

This PR adds Safari Web Extension support to the project while keeping the extension codebase single-source.

It also fixes two Safari-specific issues found during verification:
1. The options page text did not render in Safari.
2. Safari does not expose the Chrome-style action details menu, so related action menu creation is now disabled on Safari.

## Background

We want Safari support without maintaining a second copy of the extension code.

The chosen approach is:
- keep all extension logic in the existing WebExtension codebase
- generate the Safari Xcode wrapper locally from the built Safari bundle
- do not commit the generated `safari/` directory

## Changes

### Safari build / conversion
- add `dev:safari`, `build:safari`, and `safari:convert` scripts
- add a local Safari conversion script to generate the Xcode project from `dist/safari`
- make the generated Safari Xcode project reference `dist/safari` output instead of copying extension resources

### Manifest compatibility
- add Safari-specific manifest handling
- remove unsupported Safari permissions / options fields from the Safari build
- keep Firefox / Chromium behavior unchanged

### Runtime compatibility
- add Safari-safe fallbacks for:
  - i18n message lookup on the options page
  - notifications
  - preference export
  - clipboard permission handling

### Safari UX adjustments
- disable browser action context menus on Safari
- keep the main toolbar action behavior intact

### Repo hygiene
- treat `safari/` as a local generated artifact
- update `.gitignore`
- document the local Safari generation flow in `README.md`

## Why this approach

This keeps the product maintainable:
- one source of truth for extension logic
- no duplicated JS/CSS/manifest resources
- Safari wrapper stays local and disposable
- Safari-specific differences are isolated to build/runtime compatibility layers

## Testing

Validated with:
- `npm run test:tsc`
- `npm run build:safari`
- `npm run safari:convert`
- `xcodebuild -project 'safari/TongWenTang Safari/TongWenTang Safari.xcodeproj' -scheme 'TongWenTang Safari' -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`

Manual verification:
- Safari options page now has visible text via i18n fallback
- generated Safari project builds successfully
- Safari no longer tries to expose unsupported Chrome-style action menu behavior

## Notes

- Safari extension management UX differs from Chrome.
- The Chrome-style extension “three dots / details menu” is not assumed to exist on Safari anymore.
- `safari/` is intentionally local-only and should not be committed.
- Existing Rspack bundle size warnings remain unchanged and are not addressed in this PR.
